### PR TITLE
fix: Fix `publishedDate` returns the wrong date in some galleries

### DIFF
--- a/source/gallery.ts
+++ b/source/gallery.ts
@@ -55,7 +55,7 @@ export function getGallery(id: number): Promise<Gallery> {
 			});
 		}
 
-		gallery['publishedDate'] = new Date(responseJson['datepublished'] as string);
+		gallery['publishedDate'] = new Date((responseJson['datepublished'] || responseJson['date']) as string);
 
 		for(let i: number = 0; i < (responseJson['languages'] as JsonObject[])['length']; i++) {
 			gallery['translations'].push({


### PR DESCRIPTION
# Description of purpose
<!-- A clear and concise description of what the purpose is -->
Fix the `publishedDate` returns the wrong date in some galleries

# Description of changes
<!-- A clear and concise description of what the changes are -->
<img width="429" height="227" alt="스크린샷_20251002_144121" src="https://github.com/user-attachments/assets/b6b8ca99-2bcc-4b8f-8663-259ef4c0fc7a" />

Somehow, some galleries dosen't have `datepublished` value and only has `date` value.
So if `datepublished` value is `null`, it use `date` value instaed

# Additional context
<!-- Any other context or screenshots about the pull request -->